### PR TITLE
[KT-69448]: Cherry-pick textual header includes fix

### DIFF
--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1415,16 +1415,17 @@ bool ModuleMap::resolveExports(Module *Mod, bool Complain) {
 }
 
 bool ModuleMap::resolveUses(Module *Mod, bool Complain) {
-  auto Unresolved = std::move(Mod->UnresolvedDirectUses);
-  Mod->UnresolvedDirectUses.clear();
+  auto *Top = Mod->getTopLevelModule();
+  auto Unresolved = std::move(Top->UnresolvedDirectUses);
+  Top->UnresolvedDirectUses.clear();
   for (auto &UDU : Unresolved) {
-    Module *DirectUse = resolveModuleId(UDU, Mod, Complain);
+    Module *DirectUse = resolveModuleId(UDU, Top, Complain);
     if (DirectUse)
-      Mod->DirectUses.push_back(DirectUse);
+      Top->DirectUses.push_back(DirectUse);
     else
-      Mod->UnresolvedDirectUses.push_back(UDU);
+      Top->UnresolvedDirectUses.push_back(UDU);
   }
-  return !Mod->UnresolvedDirectUses.empty();
+  return !Top->UnresolvedDirectUses.empty();
 }
 
 bool ModuleMap::resolveConflicts(Module *Mod, bool Complain) {

--- a/clang/test/Modules/no-undeclared-includes.c
+++ b/clang/test/Modules/no-undeclared-includes.c
@@ -1,0 +1,31 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -fmodules-cache-path=%t -fmodules -fimplicit-module-maps -I %t %t/no-undeclared-includes.c -verify
+
+//--- no-undeclared-includes.c
+// expected-no-diagnostics
+#include <assert.h>
+
+//--- assert.h
+#include <base.h>
+
+//--- base.h
+#ifndef base_h
+#define base_h
+
+
+
+#endif /* base_h */
+
+//--- module.modulemap
+module cstd [system] [no_undeclared_includes] {
+  use base
+  module assert {
+    textual header "assert.h"
+  }
+}
+
+module base [system] {
+  header "base.h"
+  export *
+}


### PR DESCRIPTION
Our version of llvm has an issue where a textual header in a submodule or a module with `no_undeclared_includes` will not be able to resolve included headers even if the dependency is included. E.g.:
```
module a [no_undeclared_includes] {
    module text {
        textual header "a.h"
    }
    use b
}

module b {
    header "b.h"
}
```
and a header:
```
// a.h
// 'b.h' file not found
#include "b.h"
```

This patch allows `text` to start resolving headers from `use` in its parent 