### PR TITLE
KT-69637: change BUG_REPORT_URL for kotlin specific one

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -332,7 +332,7 @@ option(LLVM_TOOL_LLVM_DRIVER_BUILD "Enables building the llvm multicall tool" OF
 
 set(PACKAGE_NAME LLVM)
 set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
-set(PACKAGE_BUGREPORT "https://github.com/llvm/llvm-project/issues/")
+set(PACKAGE_BUGREPORT "https://youtrack.jetbrains.com/newIssue?project=KT")
 
 set(BUG_REPORT_URL "${PACKAGE_BUGREPORT}" CACHE STRING
   "Default URL where bug reports are to be submitted.")

--- a/llvm/utils/gn/secondary/clang/include/clang/Config/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/include/clang/Config/BUILD.gn
@@ -8,7 +8,7 @@ write_cmake_config("Config") {
   input = "config.h.cmake"
   output = "$target_gen_dir/config.h"
   values = [
-    "BUG_REPORT_URL=https://github.com/llvm/llvm-project/issues/",
+    "BUG_REPORT_URL=https://youtrack.jetbrains.com/newIssue?project=KT",
     "CLANG_DEFAULT_PIE_ON_LINUX=1",
     "CLANG_DEFAULT_LINKER=",
     "CLANG_DEFAULT_STD_C=",

--- a/llvm/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn
@@ -78,7 +78,7 @@ write_cmake_config("config") {
   input = "config.h.cmake"
   output = "$target_gen_dir/config.h"
   values = [
-    "BUG_REPORT_URL=https://github.com/llvm/llvm-project/issues/",
+    "BUG_REPORT_URL=https://youtrack.jetbrains.com/newIssue?project=KT",
     "ENABLE_BACKTRACES=1",
     "ENABLE_CRASH_OVERRIDES=1",
     "BACKTRACE_HEADER=execinfo.h",
@@ -123,7 +123,7 @@ write_cmake_config("config") {
     "LLVM_TARGET_TRIPLE_ENV=",
     "LLVM_VERSION_PRINTER_SHOW_HOST_TARGET_INFO=1",
     "LLVM_WINDOWS_PREFER_FORWARD_SLASH=",
-    "PACKAGE_BUGREPORT=https://github.com/llvm/llvm-project/issues/",
+    "PACKAGE_BUGREPORT=https://youtrack.jetbrains.com/newIssue?project=KT",
     "PACKAGE_NAME=LLVM",
     "PACKAGE_STRING=LLVM ${llvm_version}git",
     "PACKAGE_VERSION=${llvm_version}git",

--- a/utils/bazel/llvm-project-overlay/clang/include/clang/Config/config.h
+++ b/utils/bazel/llvm-project-overlay/clang/include/clang/Config/config.h
@@ -20,7 +20,7 @@
 #define CLANG_CONFIG_H
 
 /* Bug report URL. */
-#define BUG_REPORT_URL "https://github.com/llvm/llvm-project/issues/"
+#define BUG_REPORT_URL "https://youtrack.jetbrains.com/newIssue?project=KT"
 
 /* Default to -fPIE and -pie on Linux. */
 #define CLANG_DEFAULT_PIE_ON_LINUX 1

--- a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
+++ b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
@@ -24,7 +24,7 @@
 #include "llvm/Config/llvm-config.h"
 
 /* Bug report URL. */
-#define BUG_REPORT_URL "https://github.com/llvm/llvm-project/issues/"
+#define BUG_REPORT_URL "https://youtrack.jetbrains.com/newIssue?project=KT"
 
 /* Define to 1 to enable backtraces, and to 0 otherwise. */
 #define ENABLE_BACKTRACES 1
@@ -319,7 +319,7 @@
 /* LTDL_SHLIB_EXT defined in Bazel */
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "https://github.com/llvm/llvm-project/issues/"
+#define PACKAGE_BUGREPORT "https://youtrack.jetbrains.com/newIssue?project=KT"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "LLVM"


### PR DESCRIPTION
Kotlin specific forks of the LLVM-project should not suggest
  reporting encountered problems to the llvm-upstream
  and should suggest jetbrains youtrack instead.
This commit changes the BUG_REPORT_URL to the youtrack.jetbrains

^KT-69637 fixed