### PR TITLE
Use -fmacro-prefix-map for annot unit path in bc

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3311,9 +3311,10 @@ llvm::Constant *CodeGenModule::EmitAnnotationString(StringRef Str) {
 llvm::Constant *CodeGenModule::EmitAnnotationUnit(SourceLocation Loc) {
   SourceManager &SM = getContext().getSourceManager();
   PresumedLoc PLoc = SM.getPresumedLoc(Loc);
-  if (PLoc.isValid())
-    return EmitAnnotationString(PLoc.getFilename());
-  return EmitAnnotationString(SM.getBufferName(Loc));
+  StringRef Path = PLoc.isValid() ? PLoc.getFilename() : SM.getBufferName(Loc);
+  SmallString<256> RemappedPath(Path);
+  LangOpts.remapPathPrefix(RemappedPath);
+  return EmitAnnotationString(RemappedPath.str());
 }
 
 llvm::Constant *CodeGenModule::EmitAnnotationLineNo(SourceLocation L) {


### PR DESCRIPTION
    Clang emits source unit path with every annotation in llvm.metadata
    section in bitcode.

    For example, for every stdlib function annotated with
    `__attribute__((annotate("introduced_in=XXX")))` bitcode will
    contain a path to the unit the function was declared in.

    In order to make bitcode builds reproducible, these paths should be
    normalized just like `__FILE__` macro paths are.

    This commit reuses `-fmacro-prefix-map` machinery for annotation
    paths in bitcode.