### PR TITLE
[llvm-mt] Do not build llvm-mt if not functional (#134631)

### DIFF
--- a/llvm/docs/CMake.rst
+++ b/llvm/docs/CMake.rst
@@ -1150,16 +1150,6 @@ Windows
   Studio 2010 CMake generator. 0 means use all processors. Default is 0.
 
 **CMAKE_MT**:STRING
-  When compiling with clang-cl, recent CMake versions will default to selecting
-  `llvm-mt` as the Manifest Tool instead of Microsoft's `mt.exe`. This will
-  often cause errors like:
-
-  .. code-block:: console
-
-    -- Check for working C compiler: [...]clang-cl.exe - broken
-    [...]
-        MT: command [...] failed (exit code 0x1) with the following output:
-        llvm-mt: error: no libxml2
-        ninja: build stopped: subcommand failed.
-
-  To work around this error, set `CMAKE_MT=mt`.
+  When compiling with clang-cl, CMake may use `llvm-mt` as the Manifest Tool
+  when available. `llvm-mt` is only present when libxml2 is found at build-time.
+  To ensure using Microsoft's Manifest Tool set `CMAKE_MT=mt`.

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -112,7 +112,6 @@ set(LLVM_TEST_DEPENDS
           llvm-mca
           llvm-ml
           llvm-modextract
-          llvm-mt
           llvm-nm
           llvm-objcopy
           llvm-objdump
@@ -173,6 +172,10 @@ endif()
 if(TARGET LTO)
   set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} LTO)
 endif()
+
+if (TARGET llvm-mt)
+  list(APPEND LLVM_TEST_DEPENDS llvm-mt)
+endif ()
 
 if(TARGET llvm-remote-cache-test)
   set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} llvm-remote-cache-test)

--- a/llvm/test/tools/llvm-mt/help.test
+++ b/llvm/test/tools/llvm-mt/help.test
@@ -1,3 +1,4 @@
+REQUIRES: libxml2
 RUN: llvm-mt /h | FileCheck %s -check-prefix=HELP
 
 HELP:      OVERVIEW: Manifest Tool

--- a/llvm/tools/llvm-mt/CMakeLists.txt
+++ b/llvm/tools/llvm-mt/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (NOT LLVM_ENABLE_LIBXML2)
+  message(STATUS "Not building llvm-mt${CMAKE_EXECUTABLE_SUFFIX} because libxml2 is not available")
+  return()
+endif ()
+
 set(LLVM_LINK_COMPONENTS
   Option
   Support


### PR DESCRIPTION
llvm-mt requires libxml2 to work, so do not even build it without libxml2.

CMake 3.31 and later prefer llvm-mt.exe over Microsoft's mt.exe if available and using clang-cl.exe as CMAKE_CXX_COMPILER. When CMake picks up llvm-mt.exe without libxml2, any build will fail with the message
```
llvm-mt: error: no libxml2
```

Any test except `--help` already uses `REQUIRES: libxml2`. There is no point in having a non-functional executable. Not building llvm-mt.exe will force CMake to use Microsoft's `mt.exe` instead.

Fixes: #134237
(cherry picked from commit 8b11c39a0fad7f6ec48c323a0deeb3c103005200)