### PR TITLE
[KT-82766] Patch shouldIndex to index generated declarations

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -6468,8 +6468,15 @@ typedef enum {
    * indexing session associated with a \c CXIndexAction object.
    * Bodies in system headers are always skipped.
    */
-  CXIndexOpt_SkipParsedBodiesInSession = 0x10
-
+  CXIndexOpt_SkipParsedBodiesInSession = 0x10,
+  /**
+   * See KT-82766. In Kotlin Native cinterop we want to be able to index type
+   * annotated __attribute__((external_source_symbol(generated_declaration, ...
+   * such as those emitted by in the -Swift.h header. \c clang_visitChildren can
+   * already visit those, but \c clang_indexTranslationUnit is more performant, so
+   * we want to enable it to index such declarations.
+   */
+  CXIndexOpt_IndexGeneratedDeclarations = (~(unsigned)0 >> 1) + 1u
 } CXIndexOptFlags;
 
 /**

--- a/clang/include/clang/Index/IndexingOptions.h
+++ b/clang/include/clang/Index/IndexingOptions.h
@@ -37,6 +37,7 @@ struct IndexingOptions {
   // Has no effect if IndexFunctionLocals are false.
   bool IndexParametersInDeclarations = false;
   bool IndexTemplateParameters = false;
+  bool IndexGeneratedDeclarations = false;
 
   // If set, skip indexing inside some declarations for performance.
   // This prevents traversal, so skipping a struct means its declaration an

--- a/clang/lib/Index/IndexingContext.cpp
+++ b/clang/lib/Index/IndexingContext.cpp
@@ -27,6 +27,9 @@ static bool isGeneratedDecl(const Decl *D) {
 }
 
 bool IndexingContext::shouldIndex(const Decl *D) {
+  if (IndexOpts.IndexGeneratedDeclarations) {
+    return true;
+  }
   return !isGeneratedDecl(D);
 }
 

--- a/clang/tools/libclang/CXIndexDataConsumer.cpp
+++ b/clang/tools/libclang/CXIndexDataConsumer.cpp
@@ -1250,21 +1250,21 @@ static CXIdxEntityKind getEntityKindFromSymbolKind(SymbolKind K, SymbolLanguage 
   case SymbolKind::Function: return CXIdxEntity_Function;
   case SymbolKind::Variable: return CXIdxEntity_Variable;
   case SymbolKind::Field:
-    if (Lang == SymbolLanguage::ObjC)
+    if (Lang == SymbolLanguage::ObjC || Lang == SymbolLanguage::Swift)
       return CXIdxEntity_ObjCIvar;
     return CXIdxEntity_Field;
   case SymbolKind::EnumConstant: return CXIdxEntity_EnumConstant;
   case SymbolKind::Class:
-    if (Lang == SymbolLanguage::ObjC)
+    if (Lang == SymbolLanguage::ObjC || Lang == SymbolLanguage::Swift)
       return CXIdxEntity_ObjCClass;
     return CXIdxEntity_CXXClass;
   case SymbolKind::Protocol:
-    if (Lang == SymbolLanguage::ObjC)
+    if (Lang == SymbolLanguage::ObjC || Lang == SymbolLanguage::Swift)
       return CXIdxEntity_ObjCProtocol;
     return CXIdxEntity_CXXInterface;
   case SymbolKind::Extension: return CXIdxEntity_ObjCCategory;
   case SymbolKind::InstanceMethod:
-    if (Lang == SymbolLanguage::ObjC)
+    if (Lang == SymbolLanguage::ObjC || Lang == SymbolLanguage::Swift)
       return CXIdxEntity_ObjCInstanceMethod;
     return CXIdxEntity_CXXInstanceMethod;
   case SymbolKind::ClassMethod: return CXIdxEntity_ObjCClassMethod;

--- a/clang/tools/libclang/Indexing.cpp
+++ b/clang/tools/libclang/Indexing.cpp
@@ -425,6 +425,8 @@ static IndexingOptions getIndexingOptionsFromCXOptions(unsigned index_options) {
     IdxOpts.IndexFunctionLocals = true;
   if (index_options & CXIndexOpt_IndexImplicitTemplateInstantiations)
     IdxOpts.IndexImplicitInstantiation = true;
+  if (index_options & CXIndexOpt_IndexGeneratedDeclarations)
+    IdxOpts.IndexGeneratedDeclarations = true;
   return IdxOpts;
 }
 


### PR DESCRIPTION
Currently, `clang_indexTranslationUnit` doesn't emit an entity in `indexDeclaration` if it's marked `external_source_symbol (..., generated_declaration)`. We work around this in cinterop by using `clang_visitChildren`, but this call is much more expensive with `-fmodules` than `clang_indexTranslationUnit`.

This patch makes `clang_indexTranslationUnit` emit ObjC class definitions as `CXIdxEntity_CXXClass`