### PR TITLE
Introduce libKNHR (Kotlin/Native Hot-Reload Library)

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -6647,8 +6647,15 @@ typedef enum {
    * indexing session associated with a \c CXIndexAction object.
    * Bodies in system headers are always skipped.
    */
-  CXIndexOpt_SkipParsedBodiesInSession = 0x10
-
+  CXIndexOpt_SkipParsedBodiesInSession = 0x10,
+  /**
+   * See KT-82766. In Kotlin Native cinterop we want to be able to index type
+   * annotated __attribute__((external_source_symbol(generated_declaration, ...
+   * such as those emitted by in the -Swift.h header. \c clang_visitChildren can
+   * already visit those, but \c clang_indexTranslationUnit is more performant, so
+   * we want to enable it to index such declarations.
+   */
+  CXIndexOpt_IndexGeneratedDeclarations = (~(unsigned)0 >> 1) + 1u
 } CXIndexOptFlags;
 
 /**

--- a/clang/include/clang/Index/IndexingOptions.h
+++ b/clang/include/clang/Index/IndexingOptions.h
@@ -37,6 +37,7 @@ struct IndexingOptions {
   // Has no effect if IndexFunctionLocals are false.
   bool IndexParametersInDeclarations = false;
   bool IndexTemplateParameters = false;
+  bool IndexGeneratedDeclarations = false;
 
   // If set, skip indexing inside some declarations for performance.
   // This prevents traversal, so skipping a struct means its declaration an

--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -464,7 +464,7 @@ OptionalFileEntryRef FileManager::getBypassFile(FileEntryRef VF) {
 
   // If we've already bypassed just use the existing one.
   auto Insertion = SeenBypassFileEntries->insert(
-      {VF.getNameAsRequested(), std::errc::no_such_file_or_directory});
+      {VF.getName(), std::errc::no_such_file_or_directory});
   if (!Insertion.second)
     return FileEntryRef(*Insertion.first);
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3572,9 +3572,10 @@ llvm::Constant *CodeGenModule::EmitAnnotationString(StringRef Str) {
 llvm::Constant *CodeGenModule::EmitAnnotationUnit(SourceLocation Loc) {
   SourceManager &SM = getContext().getSourceManager();
   PresumedLoc PLoc = SM.getPresumedLoc(Loc);
-  if (PLoc.isValid())
-    return EmitAnnotationString(PLoc.getFilename());
-  return EmitAnnotationString(SM.getBufferName(Loc));
+  StringRef Path = PLoc.isValid() ? PLoc.getFilename() : SM.getBufferName(Loc);
+  SmallString<256> RemappedPath(Path);
+  LangOpts.remapPathPrefix(RemappedPath);
+  return EmitAnnotationString(RemappedPath.str());
 }
 
 llvm::Constant *CodeGenModule::EmitAnnotationLineNo(SourceLocation L) {

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -2075,16 +2075,9 @@ ModuleLoadResult CompilerInstance::findOrCompileModuleAndReadAST(
 
     // Check whether M refers to the file in the prebuilt module path.
     if (M && M->getASTFile())
-      if (auto ModuleFile = FileMgr->getOptionalFileRef(ModuleFilename)) {
+      if (auto ModuleFile = FileMgr->getOptionalFileRef(ModuleFilename))
         if (*ModuleFile == M->getASTFile())
           return M;
-#if !defined(__APPLE__)
-        // Workaround for ext4 file system. Also check bypass file if exists.
-        if (auto Bypass = FileMgr->getBypassFile(*ModuleFile))
-          if (*Bypass == M->getASTFile())
-            return M;
-#endif
-      }
 
     getDiagnostics().Report(ModuleNameLoc, diag::err_module_prebuilt)
         << ModuleName;

--- a/clang/lib/Frontend/Rewrite/FrontendActions.cpp
+++ b/clang/lib/Frontend/Rewrite/FrontendActions.cpp
@@ -215,12 +215,6 @@ public:
     auto File = CI.getFileManager().getOptionalFileRef(Filename);
     assert(File && "missing file for loaded module?");
 
-#if !defined(__APPLE__)
-    // Workaround for ext4 file system.
-    if (auto Bypass = CI.getFileManager().getBypassFile(*File))
-      File = *Bypass;
-#endif
-
     // Only rewrite each module file once.
     if (!Rewritten.insert(*File).second)
       return;

--- a/clang/lib/Index/IndexingContext.cpp
+++ b/clang/lib/Index/IndexingContext.cpp
@@ -39,6 +39,9 @@ void IndexingContext::setASTContext(ASTContext &ctx) {
 }
 
 bool IndexingContext::shouldIndex(const Decl *D) {
+  if (IndexOpts.IndexGeneratedDeclarations) {
+    return true;
+  }
   return !isGeneratedDecl(D);
 }
 

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -43,16 +43,6 @@ using namespace serialization;
 ModuleFile *ModuleManager::lookupByFileName(StringRef Name) const {
   auto Entry = FileMgr.getOptionalFileRef(Name, /*OpenFile=*/false,
                                           /*CacheFailure=*/false);
-#if !defined(__APPLE__)
-  if (Entry) {
-    // On Linux ext4 FileManager's inode caching system does not
-    // provide us correct behaviour for ModuleCache directories.
-    // inode can be reused after PCM delete resulting in cache misleading.
-    if (auto BypassFile = FileMgr.getBypassFile(*Entry))
-      Entry = *BypassFile;
-  }
-#endif
-
   if (Entry)
     return lookup(*Entry);
 
@@ -467,10 +457,7 @@ bool ModuleManager::lookupModuleFile(StringRef FileName, off_t ExpectedSize,
     // On Linux ext4 FileManager's inode caching system does not
     // provide us correct behaviour for ModuleCache directories.
     // inode can be reused after PCM delete resulting in cache misleading.
-    // Only use the bypass file if bypass succeed in case the underlying file
-    // system doesn't support bypass (thus there is no need for the workaround).
-    if (auto Bypass = FileMgr.getBypassFile(*File))
-      File = *Bypass;
+    File = FileMgr.getBypassFile(*File);
   }
 #endif
 

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -452,15 +452,6 @@ bool ModuleManager::lookupModuleFile(StringRef FileName, off_t ExpectedSize,
   File = FileMgr.getOptionalFileRef(FileName, /*OpenFile=*/true,
                                     /*CacheFailure=*/false);
 
-#if !defined(__APPLE__)
-  if (File) {
-    // On Linux ext4 FileManager's inode caching system does not
-    // provide us correct behaviour for ModuleCache directories.
-    // inode can be reused after PCM delete resulting in cache misleading.
-    File = FileMgr.getBypassFile(*File);
-  }
-#endif
-
   // If the file is known to the module cache but not in the filesystem, it is
   // a memory buffer. Create a virtual file for it.
   if (!File) {

--- a/clang/test/Modules/explicit-build-relpath.cpp
+++ b/clang/test/Modules/explicit-build-relpath.cpp
@@ -1,6 +1,3 @@
-/// Due to module bypass workaround in https://reviews.llvm.org/D97850 for ext4 FS, relative and absolute path do not match after bypass.
-// REQUIRES: system-darwin
-
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: cd %t

--- a/clang/tools/libclang/CXIndexDataConsumer.cpp
+++ b/clang/tools/libclang/CXIndexDataConsumer.cpp
@@ -1245,21 +1245,21 @@ static CXIdxEntityKind getEntityKindFromSymbolKind(SymbolKind K, SymbolLanguage 
   case SymbolKind::Function: return CXIdxEntity_Function;
   case SymbolKind::Variable: return CXIdxEntity_Variable;
   case SymbolKind::Field:
-    if (Lang == SymbolLanguage::ObjC)
+    if (Lang == SymbolLanguage::ObjC || Lang == SymbolLanguage::Swift)
       return CXIdxEntity_ObjCIvar;
     return CXIdxEntity_Field;
   case SymbolKind::EnumConstant: return CXIdxEntity_EnumConstant;
   case SymbolKind::Class:
-    if (Lang == SymbolLanguage::ObjC)
+    if (Lang == SymbolLanguage::ObjC || Lang == SymbolLanguage::Swift)
       return CXIdxEntity_ObjCClass;
     return CXIdxEntity_CXXClass;
   case SymbolKind::Protocol:
-    if (Lang == SymbolLanguage::ObjC)
+    if (Lang == SymbolLanguage::ObjC || Lang == SymbolLanguage::Swift)
       return CXIdxEntity_ObjCProtocol;
     return CXIdxEntity_CXXInterface;
   case SymbolKind::Extension: return CXIdxEntity_ObjCCategory;
   case SymbolKind::InstanceMethod:
-    if (Lang == SymbolLanguage::ObjC)
+    if (Lang == SymbolLanguage::ObjC || Lang == SymbolLanguage::Swift)
       return CXIdxEntity_ObjCInstanceMethod;
     return CXIdxEntity_CXXInstanceMethod;
   case SymbolKind::ClassMethod: return CXIdxEntity_ObjCClassMethod;

--- a/clang/tools/libclang/Indexing.cpp
+++ b/clang/tools/libclang/Indexing.cpp
@@ -425,6 +425,8 @@ static IndexingOptions getIndexingOptionsFromCXOptions(unsigned index_options) {
     IdxOpts.IndexFunctionLocals = true;
   if (index_options & CXIndexOpt_IndexImplicitTemplateInstantiations)
     IdxOpts.IndexImplicitInstantiation = true;
+  if (index_options & CXIndexOpt_IndexGeneratedDeclarations)
+    IdxOpts.IndexGeneratedDeclarations = true;
   return IdxOpts;
 }
 

--- a/llvm/include/llvm-c/Transforms/PassBuilder.h
+++ b/llvm/include/llvm-c/Transforms/PassBuilder.h
@@ -132,6 +132,9 @@ LLVM_C_ABI void
 LLVMPassBuilderOptionsSetInlinerThreshold(LLVMPassBuilderOptionsRef Options,
                                           int Threshold);
 
+void LLVMPassBuilderOptionsSetMaxDevirtIterations(
+    LLVMPassBuilderOptionsRef Options, int Iterations);
+
 /**
  * Dispose of a heap-allocated PassBuilderOptions instance
  */

--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -48,6 +48,7 @@ using AsyncCASIDValue = AsyncValue<CASID>;
 struct AsyncErrorValue {
   Error take() { return std::move(Value); }
 
+  AsyncErrorValue() : Value(Error::success()) {}
   AsyncErrorValue(Error &&E) : Value(std::move(E)) {}
 
 private:

--- a/llvm/include/llvm/CAS/CASID.h
+++ b/llvm/include/llvm/CAS/CASID.h
@@ -127,6 +127,7 @@ private:
 template <typename T> struct AsyncValue {
   Expected<std::optional<T>> take() { return std::move(Value); }
 
+  AsyncValue() : Value(std::nullopt) {}
   AsyncValue(Error &&E) : Value(std::move(E)) {}
   AsyncValue(T &&V) : Value(std::move(V)) {}
   AsyncValue(std::nullopt_t) : Value(std::nullopt) {}

--- a/llvm/include/llvm/Passes/PassBuilder.h
+++ b/llvm/include/llvm/Passes/PassBuilder.h
@@ -96,6 +96,9 @@ public:
   // analyses after various module->function or cgscc->function adaptors in the
   // default pipelines.
   bool EagerlyInvalidateAnalyses;
+
+  /// Tuning option to override default devirtualization iterations.
+  int MaxDevirtIterations;
 };
 
 /// This class provides access to building LLVM's passes.

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -1772,7 +1772,7 @@ void ThinLTOCodeGenerator::run() {
     };
     struct ModuleInfo {
       std::unique_ptr<AsyncModuleCacheEntry> Entry;
-      std::atomic<unsigned> State = ModuleState::MS_Empty;
+      std::atomic<unsigned> State = 0b0000;
       std::unique_ptr<MemoryBuffer> ComputedBuffer;
       std::unique_ptr<MemoryBuffer> CachedBuffer;
     };

--- a/llvm/lib/Passes/PassBuilderBindings.cpp
+++ b/llvm/lib/Passes/PassBuilderBindings.cpp
@@ -186,6 +186,11 @@ void LLVMPassBuilderOptionsSetInlinerThreshold(
   unwrap(Options)->PTO.InlinerThreshold = Threshold;
 }
 
+void LLVMPassBuilderOptionsSetMaxDevirtIterations(
+    LLVMPassBuilderOptionsRef Options, int Iterations) {
+  unwrap(Options)->PTO.MaxDevirtIterations = Iterations;
+}
+
 void LLVMDisposePassBuilderOptions(LLVMPassBuilderOptionsRef Options) {
   delete unwrap(Options);
 }

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -328,6 +328,7 @@ PipelineTuningOptions::PipelineTuningOptions() {
   UnifiedLTO = false;
   MergeFunctions = EnableMergeFunctions;
   InlinerThreshold = -1;
+  MaxDevirtIterations = -1;
   EagerlyInvalidateAnalyses = EnableEagerlyInvalidateAnalyses;
 }
 
@@ -945,9 +946,10 @@ PassBuilder::buildInlinerPipeline(OptimizationLevel Level,
   if (PGOOpt)
     IP.EnableDeferral = EnablePGOInlineDeferral;
 
+  int MDI = PTO.MaxDevirtIterations == -1 ? MaxDevirtIterations : PTO.MaxDevirtIterations;
   ModuleInlinerWrapperPass MIWP(IP, PerformMandatoryInliningsFirst,
                                 InlineContext{Phase, InlinePass::CGSCCInliner},
-                                UseInlineAdvisor, MaxDevirtIterations);
+                                UseInlineAdvisor, MDI);
 
   // Require the GlobalsAA analysis for the module so we can query it within
   // the CGSCC pipeline.

--- a/llvm/lib/Support/CrashRecoveryContext.cpp
+++ b/llvm/lib/Support/CrashRecoveryContext.cpp
@@ -344,8 +344,12 @@ static void uninstallExceptionOrSignalHandlers() {
 
 #include <signal.h>
 
+/// KOTLIN/NATIVE SPECIFIC HACK
+///
+/// We need to disable handling of signals that can originate from the JVM GC,
+/// since they should not trigger the LLVM signal handler.
 static const int Signals[] =
-    { SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGSEGV, SIGTRAP };
+    { SIGABRT, /* SIGBUS, SIGFPE, SIGILL, SIGSEGV, */ SIGTRAP };
 static const unsigned NumSignals = std::size(Signals);
 static struct sigaction PrevActions[NumSignals];
 

--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -309,6 +309,17 @@ static void RegisterHandlers() { // Not signal-safe.
 
   enum class SignalKind { IsKill, IsInfo };
   auto registerHandler = [&](int Signal, SignalKind Kind) {
+    /// KOTLIN/NATIVE SPECIFIC HACK
+    ///
+    /// We need to disable handling of signals that can originate from the JVM GC,
+    /// since they should not trigger the LLVM signal handler.
+
+    static const int JvmSigs[] = {
+      SIGILL, SIGFPE, SIGSEGV, SIGBUS, SIGUSR1, SIGUSR2
+    };
+
+    for (auto S : JvmSigs) if (Signal == S) return;
+
     unsigned Index = NumRegisteredSignals.load();
     assert(Index < std::size(RegisteredSignalInfo) &&
            "Out of space for signal handlers!");

--- a/llvm/tools/llvm-jit-shlib/CMakeLists.txt
+++ b/llvm/tools/llvm-jit-shlib/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Builds libKNHR.dylib (Kotlin/Native Hot Reload) — a shared library containing
+# the LLVM ORC JIT and JITLink components needed by Kotlin/Native hot reload.
+#
+# This is included in the "essentials" LLVM distribution so that end-user
+# compilers can link the hot reload host executable without shipping the full
+# set of LLVM static libraries.
+#
+# Enable with: -DLLVM_BUILD_KOTLIN_JIT_DYLIB=ON
+
+option(LLVM_BUILD_KOTLIN_JIT_DYLIB
+  "Build libKNHR shared library for Kotlin/Native hot reload" OFF)
+
+if(NOT LLVM_BUILD_KOTLIN_JIT_DYLIB)
+  return()
+endif()
+
+# JIT core components.
+
+set(KOTLIN_JIT_COMPONENTS
+  OrcJIT
+  OrcDebugging
+  OrcShared
+  OrcTargetProcess
+  JITLink
+  ExecutionEngine
+  RuntimeDyld
+  # Required by OrcJIT transitive deps
+  Passes
+  IRReader
+)
+
+# Conditionally add target backends based on what LLVM was configured with.
+# AArch64 covers macOS ARM64, iOS device, iOS Simulator on Apple Silicon.
+# X86 covers macOS x86_64, iOS Simulator on Intel.
+foreach(target IN ITEMS AArch64 X86)
+  if("${target}" IN_LIST LLVM_TARGETS_TO_BUILD)
+    list(APPEND KOTLIN_JIT_COMPONENTS
+      ${target}CodeGen
+      ${target}AsmParser
+      ${target}Desc
+      ${target}Disassembler
+      ${target}Info
+    )
+    if("${target}" STREQUAL "AArch64")
+      list(APPEND KOTLIN_JIT_COMPONENTS AArch64Utils)
+    endif()
+  endif()
+endforeach()
+
+llvm_map_components_to_libnames(JIT_LIB_NAMES ${KOTLIN_JIT_COMPONENTS})
+list(REMOVE_DUPLICATES JIT_LIB_NAMES)
+
+add_llvm_library(KNHR SHARED
+  DISABLE_LLVM_LINK_LLVM_DYLIB
+  OUTPUT_NAME KNHR
+  INSTALL_WITH_TOOLCHAIN
+  stub.cpp)
+
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+  # Force all symbols from static archives into the dylib.
+  set(JIT_LIB_NAMES -Wl,-all_load ${JIT_LIB_NAMES})
+else()
+  set(JIT_LIB_NAMES -Wl,--whole-archive ${JIT_LIB_NAMES} -Wl,--no-whole-archive)
+endif()
+
+target_link_libraries(KNHR PRIVATE ${JIT_LIB_NAMES})
+
+if(APPLE)
+  set_property(TARGET KNHR APPEND_STRING PROPERTY
+    LINK_FLAGS
+    " -compatibility_version 1 -current_version ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+endif()

--- a/llvm/tools/llvm-jit-shlib/stub.cpp
+++ b/llvm/tools/llvm-jit-shlib/stub.cpp
@@ -1,0 +1,12 @@
+//===- stub.cpp - Kotlin/Native Hot Reload Shared Library -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Empty file required by CMake. The actual symbols come from LLVM component
+// libraries linked into this shared library.
+//
+//===----------------------------------------------------------------------===//

--- a/llvm/unittests/Support/CrashRecoveryTest.cpp
+++ b/llvm/unittests/Support/CrashRecoveryTest.cpp
@@ -38,7 +38,12 @@ static void incrementGlobal() { ++GlobalInt; }
 static void llvmTrap() { LLVM_BUILTIN_TRAP; }
 static void incrementGlobalWithParam(void *) { ++GlobalInt; }
 
+#define SKIP_WITH_KOTLIN_PATCH() \
+  GTEST_SKIP() << "Crash recovery from SEGFAULT disabled by Kotlin patch"
+
 TEST(CrashRecoveryTest, Basic) {
+  SKIP_WITH_KOTLIN_PATCH();
+
   llvm::CrashRecoveryContext::Enable();
   GlobalInt = 0;
   EXPECT_TRUE(CrashRecoveryContext().RunSafely(incrementGlobal));
@@ -56,6 +61,8 @@ struct IncrementGlobalCleanup : CrashRecoveryContextCleanup {
 static void noop() {}
 
 TEST(CrashRecoveryTest, Cleanup) {
+  SKIP_WITH_KOTLIN_PATCH();
+
   llvm::CrashRecoveryContext::Enable();
   GlobalInt = 0;
   {
@@ -76,6 +83,8 @@ TEST(CrashRecoveryTest, Cleanup) {
 }
 
 TEST(CrashRecoveryTest, DumpStackCleanup) {
+  SKIP_WITH_KOTLIN_PATCH();
+
   SmallString<128> Filename;
   std::error_code EC = sys::fs::createTemporaryFile("crash", "test", Filename);
   EXPECT_FALSE(EC);


### PR DESCRIPTION
Create a new custom LLVM component used to support HotReload runtime within Kotlin/Native's one, **libKNHR**. The library uses the new LLVM ORCv2 APIs, with JITLink support, to create new symbols at runtime and overposing theme (through stubs creation). The library is created by setting the CMake variable `-DLLVM_BUILD_KOTLIN_JIT_DYLIB=ON`.

At the moment, only Darwin targets are supported (specifically, the runtime has been tested on macOS Arm64). We plan in the future to support other targets, such as `iossim` and `ios`. 