### PR TITLE
[FunctionSpecialization] Strip ptrauth bundles from devirtualized calls

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -961,6 +961,40 @@ Function *FunctionSpecializer::createSpecialization(Function *F,
                                                     const SpecSig &S) {
   Function *Clone = cloneCandidateFunction(F, Specializations.size() + 1);
 
+  // IPSCCP will rewrite indirect calls in the clone to direct calls when it
+  // propagates the substituted Function constants via replaceAllUsesWith,
+  // which does not touch operand bundles. The verifier rejects direct calls
+  // carrying a ptrauth bundle, so strip those bundles from any call whose
+  // callee is a formal being specialized to a Function constant.
+  DenseSet<Argument *> ArgsToFunction;
+  for (const ArgInfo &A : S.Args)
+    if (isa<Function>(A.Actual->stripPointerCasts()))
+      ArgsToFunction.insert(Clone->getArg(A.Formal->getArgNo()));
+
+  if (!ArgsToFunction.empty()) {
+    for (BasicBlock &BB : *Clone) {
+      for (Instruction &I : make_early_inc_range(BB)) {
+        auto *CB = dyn_cast<CallBase>(&I);
+        if (!CB)
+          continue;
+        auto *ArgCallee = dyn_cast<Argument>(CB->getCalledOperand());
+        if (!ArgCallee || !ArgsToFunction.contains(ArgCallee))
+          continue;
+        if (!CB->getOperandBundle(LLVMContext::OB_ptrauth))
+          continue;
+
+        SmallVector<OperandBundleDef, 2> NewBundles;
+        CB->getOperandBundlesAsDefs(NewBundles);
+        llvm::erase_if(NewBundles, [](const OperandBundleDef &D) {
+          return D.getTag() == "ptrauth";
+        });
+        CallBase *NewCB = CallBase::Create(CB, NewBundles, CB->getIterator());
+        CB->replaceAllUsesWith(NewCB);
+        CB->eraseFromParent();
+      }
+    }
+  }
+
   // The original function does not neccessarily have internal linkage, but the
   // clone must.
   Clone->setLinkage(GlobalValue::InternalLinkage);

--- a/llvm/test/Transforms/FunctionSpecialization/ptrauth-bundle-strip.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/ptrauth-bundle-strip.ll
@@ -1,0 +1,129 @@
+; RUN: opt -S -passes="ipsccp<func-spec>" -force-specialization < %s | FileCheck %s
+
+;; FunctionSpecialization clones a function with a function-pointer constant
+;; substituted into the body. IPSCCP then rewrites the indirect call
+;;
+;;   call void %fn_param() [ "ptrauth"(i32 0, i64 0) ]   ; LEGAL indirect
+;;
+;; into a direct call by replacing %fn_param with the Function constant. The
+;; operand bundle is not touched by replaceAllUsesWith, so the result would be
+;;
+;;   call void @callee() [ "ptrauth"(i32 0, i64 0) ]     ; ILLEGAL direct
+;;
+;; which the verifier rejects ("Direct call cannot have a ptrauth bundle").
+;; The fix in FunctionSpecializer::createSpecialization strips ptrauth bundles
+;; from calls in the clone whose callee is one of the formal arguments being
+;; specialized to a Function constant, before IPSCCP propagates the constant.
+;;
+;; Callers pass *different* function constants so IPSCCP cannot do in-place
+;; propagation and must rely on FunctionSpecialization to clone the helper
+;; per constant — which is the path that triggers the original Kotlin/Native
+;; arm64e crash.
+
+target triple = "arm64e-apple-ios14.0.0"
+
+@global_fn_ptr = external global ptr
+
+define void @callee1() {
+entry:
+  ret void
+}
+
+define void @callee2() {
+entry:
+  ret void
+}
+
+;; ---------------------------------------------------------------------------
+;; Positive (call form): bundle MUST be stripped from the devirtualized call.
+;; ---------------------------------------------------------------------------
+
+define internal void @helper_call(ptr %fn) {
+entry:
+  call void %fn() [ "ptrauth"(i32 0, i64 0) ]
+  ret void
+}
+
+define void @caller_call_a() {
+  call void @helper_call(ptr @callee1)
+  ret void
+}
+
+define void @caller_call_b() {
+  call void @helper_call(ptr @callee2)
+  ret void
+}
+
+;; FuncSpec's global .specialized.N counter is fragile to traversal order, so
+;; we only require the clones exist — the verifier rejects ill-formed direct
+;; calls, so the mere fact that opt produces output proves no devirtualized
+;; call carries a ptrauth bundle.
+; CHECK-DAG: @helper_call.specialized
+; CHECK-DAG: @helper_call.specialized
+
+;; ---------------------------------------------------------------------------
+;; Positive (invoke form): bundle MUST be stripped from the devirtualized
+;; invoke. This mirrors the original Kotlin/Native crash shape.
+;; ---------------------------------------------------------------------------
+
+declare i32 @__gxx_personality_v0(...)
+
+define internal void @helper_invoke(ptr %fn) personality ptr @__gxx_personality_v0 {
+entry:
+  invoke void %fn() [ "ptrauth"(i32 0, i64 0) ]
+          to label %cont unwind label %lpad
+
+cont:
+  ret void
+
+lpad:
+  %lp = landingpad { ptr, i32 } cleanup
+  resume { ptr, i32 } %lp
+}
+
+define void @caller_invoke_a() {
+  call void @helper_invoke(ptr @callee1)
+  ret void
+}
+
+define void @caller_invoke_b() {
+  call void @helper_invoke(ptr @callee2)
+  ret void
+}
+
+; CHECK-DAG: @helper_invoke.specialized
+; CHECK-DAG: @helper_invoke.specialized
+
+;; ---------------------------------------------------------------------------
+;; Negative: a ptrauth bundle on a still-indirect call (callee is loaded from
+;; a global, not from the substituted argument) MUST be preserved. Guards
+;; against an over-eager fix that strips bundles unconditionally.
+;; ---------------------------------------------------------------------------
+
+define internal void @helper_mixed(ptr %fn) {
+entry:
+  ; Devirtualized — bundle stripped.
+  call void %fn() [ "ptrauth"(i32 0, i64 0) ]
+  ; Still indirect — bundle preserved.
+  %loaded = load ptr, ptr @global_fn_ptr
+  call void %loaded() [ "ptrauth"(i32 0, i64 0) ]
+  ret void
+}
+
+define void @caller_mixed_a() {
+  call void @helper_mixed(ptr @callee1)
+  ret void
+}
+
+define void @caller_mixed_b() {
+  call void @helper_mixed(ptr @callee2)
+  ret void
+}
+
+; CHECK-DAG: @helper_mixed.specialized
+; CHECK-DAG: @helper_mixed.specialized
+
+;; The mixed helper's still-indirect call (through a loaded fn-pointer)
+;; retains its ptrauth bundle in every clone. Guards against an over-eager
+;; fix that strips bundles unconditionally.
+; CHECK-COUNT-2: call void %{{.*}}() [ "ptrauth"(i32 0, i64 0) ]


### PR DESCRIPTION
Downstream apply of a proposed upstream LLVM fix needed to unblock the arm64e Kotlin/Native target. Without it, FunctionSpecializationPass fails the IR verifier with:

  Direct call cannot have a ptrauth bundle
    invoke void @"sym"() [ "ptrauth"(i32 0, i64 0) ]
            to label %52 unwind label %55

Root cause: when FunctionSpecialization clones a function with a constant function-pointer argument substituted into the body, an indirect call

  invoke void %fn_ptr_param() [ "ptrauth"(i32 0, i64 0) ]  ; LEGAL indirect

becomes a direct call after IPSCCP's V->replaceAllUsesWith(Const):

  invoke void @"sym"()        [ "ptrauth"(i32 0, i64 0) ]  ; ILLEGAL direct

The verifier rejects: the ptrauth bundle is only meaningful on indirect calls (it tells the backend which key/discriminator to use to authenticate the loaded function pointer before branching). replaceAllUsesWith only rewrites the called operand; it does not touch operand bundles.

Concrete reproducer from K/N arm64e bring-up: CallInitGlobalPossiblyLock (a runtime helper) takes a fn-pointer arg and invokes it with a ptrauth bundle. FunctionSpecialization produces
@CallInitGlobalPossiblyLock.specialized.1 and rewrites the indirect invoke into a direct invoke to @"kfun:kotlin.text.\$init_global#internal.2", with the bundle still attached. Compilation aborts at the verifier.

Fix: in FunctionSpecializer::createSpecialization, after cloning the function, walk the clone body and strip ptrauth operand bundles from any CallBase whose callee is one of the formal Arguments being specialized to a Function constant. This pre-empts the IPSCCP rewrite so the bundle is gone before the indirect-to-direct transition. Other operand bundles are preserved; non-PAC targets are unaffected (no calls carry ptrauth bundles).

Test: llvm/test/Transforms/FunctionSpecialization/ptrauth-bundle-strip.ll. Triggers via -passes="ipsccp<func-spec>" -force-specialization with callers passing different Function constants (forces the FuncSpec clone path). Without the fix, opt aborts with the verifier error above. With the fix, specialized clones contain direct calls with no ptrauth bundle; a sibling negative case confirms bundles are preserved on still-indirect calls.

Verified end-to-end against upstream llvm/llvm-project main:
- Test fails (verifier abort) without the fix.
- Test passes with the fix.
- llvm/test/Transforms/FunctionSpecialization/ all pass (60/62, 2 pre-existing UNSUPPORTED).
- llvm/test/Transforms/IPO/ and SCCP/ all pass (175/176, 1 pre-existing UNSUPPORTED).
- clang-format clean.

Filed upstream: TBD (llvm/llvm-project PR). This downstream apply lets Kotlin/Native delete its StripDirectCallPtrauthBundlesPass workaround (kotlin-native/backend.native/.../optimizations/StripDirectCallPtrauthBundlesPass.kt, libllvmext/src/main/cpp/StripDirectCallPtrauthBundles.cpp, and the Bitcode.kt phase wiring).

Note: a related variant of this bug exists on the IPSCCP in-place constant-propagation path (when all callers pass the same Function constant, FuncSpec is bypassed and IPSCCP rewrites the original function in-place). That path is not addressed here and would need a corresponding fix in SCCPSolver. The Kotlin/Native trigger is the FuncSpec clone path.